### PR TITLE
Add support for identifying a git detached head

### DIFF
--- a/powerline-zsh.py
+++ b/powerline-zsh.py
@@ -200,7 +200,7 @@ def add_git_segment(powerline, cwd):
 
     has_pending_commits, has_untracked_files, origin_position, detached_head, current_branch = get_git_status()
 
-    if current_branch:
+    if len(current_branch) > 0:
       branch = current_branch
     elif detached_head:
        branch = subprocess.Popen(['git', 'describe', '--all', '--contains', '--abbrev=4', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
When working with remotes, it is nice to be able to detect/display when you are in a detached head.  This change should address that.

Side note: this is a sweet implementation of powerline-bash!
