### PR TITLE
Make sure it's always run with python2, not python3

### DIFF
--- a/powerline-zsh.py
+++ b/powerline-zsh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import os


### PR DESCRIPTION
When using the "python" env variable, it may end up being run with python3 (for example, when one is working under a python3 virtualenv), and this causes syntax errors, because the script is written only for python2. Instead, we can just use the "python2" variable, which points to the current python 2 interpreter.
