### PR TITLE
Fixed a git problem

### DIFF
--- a/powerline-zsh.py
+++ b/powerline-zsh.py
@@ -199,7 +199,7 @@ def add_git_segment(powerline, cwd):
     p = subprocess.Popen(['git', 'symbolic-ref', '-q', 'HEAD'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = p.communicate()
 
-    if 'Not a git repo' in err.decode(encoding):
+    if 'not a git repo' in err.decode(encoding).lower():
         return False
 
     if out:


### PR DESCRIPTION
I had a problem, because every time I entered directory that was not a git repository, it showed `fatal: not a git repository (or any of the parent directories): .git`.

I checked the code and found that you are using regex in `add_git_segment` function. I am not sure if it is because of my version of git or something else, but my git error begins with a lowercase n.

I am on Manjaro 4.14.56-1, zsh 5.5.1 and git version 2.18.0 if it helps

Powerline for zsh is awesome! :+1: 